### PR TITLE
ContentNodeRepository: also fetch root and parent of contentNode

### DIFF
--- a/api/src/Repository/ContentNodeRepository.php
+++ b/api/src/Repository/ContentNodeRepository.php
@@ -30,4 +30,14 @@ class ContentNodeRepository extends SortableServiceEntityRepository implements C
     public function filterByUser(QueryBuilder $queryBuilder, User $user): void {
         $this->filterByContentNode($queryBuilder, $user, $queryBuilder->getRootAliases()[0]);
     }
+
+    public function createQueryBuilder($alias, $indexBy = null): QueryBuilder {
+        $qb = parent::createQueryBuilder($alias, $indexBy);
+        $qb->select("{$alias}", 'fetchRoot', 'fetchParent', 'fetchParentOfParent');
+        $qb->leftJoin("{$alias}.root", 'fetchRoot');
+        $qb->leftJoin("{$alias}.parent", 'fetchParent');
+        $qb->leftJoin('fetchParent.parent', 'fetchParentOfParent');
+
+        return $qb;
+    }
 }

--- a/api/tests/Api/SnapshotTests/__snapshots__/EndpointQueryCountTest__testNumberOfQueriesDidNotChange__1.yml
+++ b/api/tests/Api/SnapshotTests/__snapshots__/EndpointQueryCountTest__testNumberOfQueriesDidNotChange__1.yml
@@ -10,7 +10,7 @@
 /camp_collaborations/item: 15
 /categories: 11
 /categories/item: 9
-/content_nodes: 9
+/content_nodes: 8
 /content_node/column_layouts: 6
 /content_node/column_layouts/item: 10
 /content_node/material_nodes: 6


### PR DESCRIPTION
With the ResponsiveLayout, we now have mostly ContentNodes which are nested by 2 levels: ColumnLayout -> DefaultLayout -> "Content Nodes with content" This may lead to n+1 db queries that we experienced in the EndpointQueryCountTest.

@manuelmeister
You can either merge this PR, or https://github.com/manuelmeister/ecamp3/pull/5