### PR TITLE
[perf] Remove N+1 query in ChecklistNodePersistProcessor

### DIFF
--- a/api/src/State/ContentNode/ChecklistNodePersistProcessor.php
+++ b/api/src/State/ContentNode/ChecklistNodePersistProcessor.php
@@ -23,21 +23,28 @@ class ChecklistNodePersistProcessor extends ContentNodePersistProcessor {
         /** @var ChecklistNode $data */
         $data = parent::onBefore($data, $operation, $uriVariables, $context);
 
+        $allIds = array_unique(array_merge($data->addChecklistItemIds ?? [], $data->removeChecklistItemIds ?? []));
+        $checklistItems = [];
+        if (!empty($allIds)) {
+            $fetchedItems = $this->checklistItemRepository->findBy(['id' => $allIds]);
+            foreach ($fetchedItems as $item) {
+                $checklistItems[$item->getId()] = $item;
+            }
+        }
+
         if (null !== $data->addChecklistItemIds) {
             foreach ($data->addChecklistItemIds as $checklistItemId) {
-                $checklistItem = $this->checklistItemRepository->find($checklistItemId);
-                if (null != $checklistItem) {
+                if (isset($checklistItems[$checklistItemId])) {
                     // if a checklistItem does not exists, do not add it
-                    $data->addChecklistItem($checklistItem);
+                    $data->addChecklistItem($checklistItems[$checklistItemId]);
                 }
             }
         }
         if (null !== $data->removeChecklistItemIds) {
             foreach ($data->removeChecklistItemIds as $checklistItemId) {
-                $checklistItem = $this->checklistItemRepository->find($checklistItemId);
-                if (null != $checklistItem) {
+                if (isset($checklistItems[$checklistItemId])) {
                     // if a checklistItem no longer exists, it does not have to be removed
-                    $data->removeChecklistItem($checklistItem);
+                    $data->removeChecklistItem($checklistItems[$checklistItemId]);
                 }
             }
         }

--- a/api/src/State/ContentNode/ChecklistNodePersistProcessor.php
+++ b/api/src/State/ContentNode/ChecklistNodePersistProcessor.php
@@ -27,9 +27,7 @@ class ChecklistNodePersistProcessor extends ContentNodePersistProcessor {
         $checklistItems = [];
         if (!empty($allIds)) {
             $fetchedItems = $this->checklistItemRepository->findBy(['id' => $allIds]);
-            foreach ($fetchedItems as $item) {
-                $checklistItems[$item->getId()] = $item;
-            }
+            $checklistItems = array_column($fetchedItems, null, 'id');
         }
 
         if (null !== $data->addChecklistItemIds) {

--- a/api/src/Validator/ChecklistItem/AssertBelongsToSameCampValidator.php
+++ b/api/src/Validator/ChecklistItem/AssertBelongsToSameCampValidator.php
@@ -42,9 +42,15 @@ class AssertBelongsToSameCampValidator extends ConstraintValidator {
 
         $camp = $this->getCampFromInterface($object, $this->em);
 
+        $checklistItems = [];
+        if (!empty($value)) {
+            $fetchedItems = $this->checklistItemRepository->findBy(['id' => $value]);
+            $checklistItems = array_column($fetchedItems, null, 'id');
+        }
+
         foreach ($value as $checklistItemId) {
             /** @var ?ChecklistItem $checklistItem */
-            $checklistItem = $this->checklistItemRepository->find($checklistItemId);
+            $checklistItem = $checklistItems[$checklistItemId] ?? null;
 
             if ($camp != $checklistItem?->getCamp()) {
                 $this->context->buildViolation($constraint->message)


### PR DESCRIPTION
💡 **What:** The optimization implemented involves bulk fetching `ChecklistItem` entities in `ChecklistNodePersistProcessor`. Instead of querying the database for each ID in `addChecklistItemIds` and `removeChecklistItemIds` individually, I now collect all unique IDs and perform a single `findBy(['id' => $allIds])` call.

🎯 **Why:** The previous implementation followed an $N+1$ query pattern, which is a common performance bottleneck. For each item being added or removed, a separate database round-trip was required. This could significantly slow down the persist operation when dealing with multiple checklist items.

📊 **Measured Improvement:** While I was unable to run a live benchmark due to PHP version requirements (8.4 required, 8.3 available in the environment), this change is a well-established optimization that reduces the query count from up to $O(2N)$ queries to just $O(1)$. This provides a guaranteed performance improvement in terms of database load and latency, especially as the number of checklist items increases.

---
*PR created automatically by Jules for task [3097280051793586952](https://jules.google.com/task/3097280051793586952) started by @manuelmeister*