### PR TITLE
fix: prevent circular serialization loop between User and Profile entities

### DIFF
--- a/api/src/Entity/Profile.php
+++ b/api/src/Entity/Profile.php
@@ -35,7 +35,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: 'is_authenticated()'
         ),
     ],
-    normalizationContext: ['groups' => ['read']],
+    normalizationContext: ['groups' => ['Profile:read', 'read']],
     denormalizationContext: ['groups' => ['write']],
 )]
 #[ApiFilter(filterClass: SearchFilter::class, properties: ['user.collaborations.camp', 'user'])]
@@ -56,7 +56,7 @@ class Profile extends BaseEntity {
     #[Assert\NotBlank]
     #[Assert\Email]
     #[ApiProperty(example: self::EXAMPLE_EMAIL)]
-    #[Groups(['read', 'create'])]
+    #[Groups(['Profile:read', 'create'])]
     #[ORM\Column(type: 'string', length: 64, unique: true, nullable: false)]
     public ?string $email = null;
 
@@ -137,7 +137,7 @@ class Profile extends BaseEntity {
     #[InputFilter\CleanText]
     #[Assert\Length(max: 64)]
     #[ApiProperty(example: self::EXAMPLE_FIRSTNAME)]
-    #[Groups(['read', 'write'])]
+    #[Groups(['Profile:read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $firstname = null;
 
@@ -148,7 +148,7 @@ class Profile extends BaseEntity {
     #[InputFilter\CleanText]
     #[Assert\Length(max: 64)]
     #[ApiProperty(example: self::EXAMPLE_SURNAME)]
-    #[Groups(['read', 'write'])]
+    #[Groups(['Profile:read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $surname = null;
 
@@ -159,7 +159,7 @@ class Profile extends BaseEntity {
     #[InputFilter\CleanText]
     #[Assert\Length(max: 32)]
     #[ApiProperty(example: self::EXAMPLE_NICKNAME)]
-    #[Groups(['read', 'write'])]
+    #[Groups(['Profile:read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $nickname = null;
 
@@ -169,7 +169,7 @@ class Profile extends BaseEntity {
     #[InputFilter\Trim]
     #[ApiProperty(example: self::EXAMPLE_LANGUAGE)]
     #[Assert\Choice(choices: Languages::SUPPORTED_LANGUAGES)]
-    #[Groups(['read', 'write'])]
+    #[Groups(['Profile:read', 'write'])]
     #[ORM\Column(type: 'string', length: 20, nullable: true)]
     public ?string $language = null;
 
@@ -179,7 +179,7 @@ class Profile extends BaseEntity {
     #[InputFilter\Trim]
     #[Assert\Regex(pattern: '/^#[0-9a-zA-Z]{6}$/')]
     #[ApiProperty(example: '#4DBB52')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['Profile:read', 'write'])]
     #[ORM\Column(type: 'string', length: 8, nullable: true)]
     public ?string $color = null;
 
@@ -189,7 +189,7 @@ class Profile extends BaseEntity {
     #[InputFilter\Trim]
     #[Assert\Length(max: 2, countUnit: Assert\Length::COUNT_GRAPHEMES)]
     #[ApiProperty(example: 'AB')]
-    #[Groups(['read', 'write'])]
+    #[Groups(['Profile:read', 'write'])]
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $abbreviation = null;
 
@@ -201,7 +201,7 @@ class Profile extends BaseEntity {
     public array $roles = ['ROLE_USER'];
 
     #[ApiProperty(writable: false, readableLink: true, example: '/users/1a2b3c4d')]
-    #[Groups(['read'])]
+    #[Groups(['Profile:read'])]
     #[ORM\OneToOne(targetEntity: User::class, mappedBy: 'profile')]
     public User $user;
 
@@ -225,7 +225,7 @@ class Profile extends BaseEntity {
      * documents. Falls back to the nickname if not complete.
      */
     #[ApiProperty(example: 'Robert Baden-Powell')]
-    #[Groups(['read'])]
+    #[Groups(['Profile:read'])]
     public function getLegalName(): ?string {
         if (!empty($this->firstname) && !empty($this->surname)) {
             return $this->firstname.' '.$this->surname;

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -49,7 +49,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: 'false'
         ),
         new Post(
-            normalizationContext: ['groups' => ['read', 'User:create']],
+            normalizationContext: ['groups' => ['User:read', 'read', 'User:create']],
             denormalizationContext: ['groups' => ['write', 'create']],
             security: 'true',
             // allow unauthenticated clients to create (register) users
@@ -57,7 +57,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             processor: UserCreateProcessor::class
         ),
     ],
-    normalizationContext: ['groups' => ['read']],
+    normalizationContext: ['groups' => ['User:read', 'read']],
     denormalizationContext: ['groups' => ['write']],
 )]
 #[UniqueEntity(
@@ -195,7 +195,7 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
      * A displayable name of the user.
      */
     #[ApiProperty(example: 'Robert Baden-Powell')]
-    #[Groups(['read'])]
+    #[Groups(['User:read', 'Profile:read'])]
     public function getDisplayName(): ?string {
         return $this->profile->getDisplayName();
     }
@@ -204,7 +204,7 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
      * A displayable name of the user.
      */
     #[ApiProperty(example: '#ff0000')]
-    #[Groups(['read'])]
+    #[Groups(['User:read', 'Profile:read'])]
     public function getColor(): ?string {
         return $this->profile->color;
     }
@@ -213,14 +213,14 @@ class User extends BaseEntity implements UserInterface, PasswordAuthenticatedUse
      * A displayable name of the user.
      */
     #[ApiProperty(example: 'AB')]
-    #[Groups(['read'])]
+    #[Groups(['User:read', 'Profile:read'])]
     public function getAbbreviation(): ?string {
         return $this->profile->abbreviation;
     }
 
     #[ApiProperty]
     #[SerializedName('profile')]
-    #[Groups(['read'])]
+    #[Groups(['User:read'])]
     public function getProfile(): Profile {
         return $this->profile;
     }


### PR DESCRIPTION
This commit fixes an issue where fetching `/api/profiles` or `/api/users` could result in a 502 Bad Gateway / Segmentation Fault due to an infinite circular recursion.

The problem stems from the `User` and `Profile` entities globally sharing the `['read']` normalization group.

This change spaces out the serialization by:
1. Re-assigning all specific properties within `User` mapped with `['read']` to use `['User:read', 'Profile:read']`, except for the embedded `$profile` relation which is exclusively mapped to `['User:read']`.
2. Updating `User`'s root normalizer context to include `User:read` alongside the existing `read` context.
3. Re-assigning all specific properties within `Profile` mapped with `['read']` to use `['Profile:read']`.
4. Updating `Profile`'s root normalizer context to include `Profile:read` alongside the existing `read` context.

By ensuring the `$profile` property embedded within `User` lacks the `Profile:read` group, API platform stops serialization when embedding the user back inside the profile when responding to `/api/profiles`. Base attributes such as `$id` inherited from `BaseEntity` with `['read']` are preserved as `'read'` is preserved in the base normalizer context.

---
*PR created automatically by Jules for task [16918674916046857025](https://jules.google.com/task/16918674916046857025) started by @manuelmeister*