### PR TITLE
Replace checklist navigation length check with isCourse flag

### DIFF
--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -710,6 +710,13 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
         return $this;
     }
 
+    #[ApiProperty(readable: true, writable: false)]
+    #[Groups(['read'])]
+    #[SerializedName('isCourse')]
+    public function getIsCourse(): bool {
+        return $this->checklists->count() > 0;
+    }
+
     /**
      * @return Checklist[]
      */

--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -470,6 +470,13 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
         $this->comments = new ArrayCollection();
     }
 
+    #[ApiProperty(readable: true, writable: false)]
+    #[Groups(['read'])]
+    #[SerializedName('isCourse')]
+    public function getIsCourse(): bool {
+        return $this->checklists->count() > 0;
+    }
+
     /**
      * @return Period[]
      */
@@ -708,13 +715,6 @@ class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototy
         }
 
         return $this;
-    }
-
-    #[ApiProperty(readable: true, writable: false)]
-    #[Groups(['read'])]
-    #[SerializedName('isCourse')]
-    public function getIsCourse(): bool {
-        return $this->checklists->count() > 0;
     }
 
     /**

--- a/frontend/src/views/camp/navigation/desktop/NavTopbar.vue
+++ b/frontend/src/views/camp/navigation/desktop/NavTopbar.vue
@@ -14,7 +14,7 @@
         :text="$t('views.camp.navigation.desktop.navTopbar.program')"
       />
       <TopNavigationItem
-        v-if="hasChecklist"
+        v-if="camp.isCourse"
         :to="campRoute(camp, 'overview/checklists')"
         icon="mdi-clipboard-list-outline"
         :text="$t('views.camp.navigation.desktop.navTopbar.checklist')"
@@ -72,9 +72,6 @@ export default {
     }
   },
   computed: {
-    hasChecklist() {
-      return this.camp.checklists().items.length > 0
-    },
     helpLink() {
       return getEnv().HELP_LINK
     },

--- a/frontend/src/views/camp/navigation/mobile/NavSidebar.vue
+++ b/frontend/src/views/camp/navigation/mobile/NavSidebar.vue
@@ -64,11 +64,12 @@
         />
         <v-divider inset />
         <SidebarListItem
+          v-if="camp.isCourse"
           :to="campRoute(camp, 'overview/checklists')"
           :title="$t('views.camp.navigation.mobile.navSidebar.itemChecklists')"
           icon="mdi-clipboard-list-outline"
         />
-        <v-divider inset />
+        <v-divider v-if="camp.isCourse" inset />
         <SidebarListItem
           :title="$t('views.camp.navigation.mobile.navSidebar.itemCollaborators')"
           icon="mdi-account-group"


### PR DESCRIPTION
This change introduces an `isCourse` boolean to the `Camp` response from the backend. This boolean indicates if a camp has checklists or not. The frontend then uses `isCourse` to show/hide the checklist tab.

Changes made:
- Added `getIsCourse` to `Camp.php` with `#[ApiProperty]` and `#[Groups(['read'])]` attributes, evaluating to `$this->checklists->count() > 0`.
- In `frontend/src/views/camp/navigation/desktop/NavTopbar.vue`, removed `hasChecklist` computed property and replaced it with `camp.isCourse`.
- In `frontend/src/views/camp/navigation/mobile/NavSidebar.vue`, added `v-if="camp.isCourse"` to the Checklist `SidebarListItem` and its adjacent `v-divider`.

---
*PR created automatically by Jules for task [16322604611589849870](https://jules.google.com/task/16322604611589849870) started by @manuelmeister*